### PR TITLE
Fix undefined get_locale in templates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 from flask import Flask, g, request, redirect, url_for, session, render_template, send_from_directory
+from flask_babel import get_locale as babel_get_locale
 from .config import Config
 from .extensions import db, migrate, login_manager, babel
 
@@ -53,6 +54,14 @@ def create_app(config_class: type = Config) -> Flask:
     from .cli import register_cli
 
     register_cli(app)
+
+    @app.context_processor
+    def inject_get_locale():
+        # Expose get_locale() to Jinja templates as a callable returning a string like 'en' or 'ar'
+        def _get_locale():
+            return str(babel_get_locale())
+
+        return {"get_locale": _get_locale}
 
     @app.route("/")
     def index():


### PR DESCRIPTION
Expose `get_locale` to Jinja templates to resolve `UndefinedError` when `base.html` attempts to call it.

---
<a href="https://cursor.com/background-agent?bcId=bc-c85f451f-b3c1-4723-bece-3bedd8abe2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c85f451f-b3c1-4723-bece-3bedd8abe2f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

