### PR TITLE
Allow tenant to view and update requests

### DIFF
--- a/app/templates/tenant/complaint_detail.html
+++ b/app/templates/tenant/complaint_detail.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Complaint') }} #{{ c.id }}{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h3 class="m-0">{{ _('Complaint') }} #{{ c.id }}</h3>
+  <a class="btn btn-secondary" href="{{ url_for('tenant.dashboard') }}">{{ _('Back') }}</a>
+</div>
+
+<div class="card re-card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-start mb-2">
+      <div>
+        <div class="h5 m-0">{{ c.subject }}</div>
+        <div class="text-muted small">{{ _('Created') }}: {{ c.created_at }} · {{ _('Updated') }}: {{ c.updated_at or '-' }}</div>
+      </div>
+      <span class="badge text-bg-secondary">{{ c.status }}</span>
+    </div>
+    <p class="mb-0">{{ c.description }}</p>
+  </div>
+</div>
+{% endblock %}
+

--- a/app/templates/tenant/dashboard.html
+++ b/app/templates/tenant/dashboard.html
@@ -59,13 +59,15 @@
         <ul class="list-group list-group-flush">
           {% for m in maintenance_requests %}
           <li class="list-group-item">
-            <div class="d-flex justify-content-between">
-              <div>
-                <strong>{{ m.title }}</strong>
-                <div class="text-muted small">{{ m.description }}</div>
+            <a class="text-decoration-none d-block" href="{{ url_for('tenant.maintenance_detail', request_id=m.id) }}">
+              <div class="d-flex justify-content-between">
+                <div>
+                  <strong>{{ m.title }}</strong>
+                  <div class="text-muted small">{{ m.description }}</div>
+                </div>
+                <span class="badge text-bg-secondary">{{ m.status }}</span>
               </div>
-              <span class="badge text-bg-secondary">{{ m.status }}</span>
-            </div>
+            </a>
           </li>
           {% else %}
           <li class="list-group-item">{{ _('No data') }}</li>
@@ -85,13 +87,15 @@
         <ul class="list-group list-group-flush">
           {% for c in complaints %}
           <li class="list-group-item">
-            <div class="d-flex justify-content-between">
-              <div>
-                <strong>{{ c.subject }}</strong>
-                <div class="text-muted small">{{ c.description }}</div>
+            <a class="text-decoration-none d-block" href="{{ url_for('tenant.complaint_detail', complaint_id=c.id) }}">
+              <div class="d-flex justify-content-between">
+                <div>
+                  <strong>{{ c.subject }}</strong>
+                  <div class="text-muted small">{{ c.description }}</div>
+                </div>
+                <span class="badge text-bg-secondary">{{ c.status }}</span>
               </div>
-              <span class="badge text-bg-secondary">{{ c.status }}</span>
-            </div>
+            </a>
           </li>
           {% else %}
           <li class="list-group-item">{{ _('No data') }}</li>

--- a/app/templates/tenant/maintenance_detail.html
+++ b/app/templates/tenant/maintenance_detail.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Maintenance Request') }} #{{ m.id }}{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h3 class="m-0">{{ _('Maintenance Request') }} #{{ m.id }}</h3>
+  <a class="btn btn-secondary" href="{{ url_for('tenant.dashboard') }}">{{ _('Back') }}</a>
+</div>
+
+<div class="card re-card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-start mb-2">
+      <div>
+        <div class="h5 m-0">{{ m.title }}</div>
+        <div class="text-muted small">{{ _('Created') }}: {{ m.created_at }} · {{ _('Updated') }}: {{ m.updated_at or '-' }}</div>
+      </div>
+      <span class="badge text-bg-secondary">{{ m.status }}</span>
+    </div>
+    <p class="mb-0">{{ m.description }}</p>
+  </div>
+</div>
+{% endblock %}
+

--- a/app/tenant/routes.py
+++ b/app/tenant/routes.py
@@ -90,3 +90,22 @@ def complaint_create():
         return redirect(url_for("tenant.dashboard"))
     return render_template("tenant/complaint_form.html")
 
+
+@tenant_bp.route("/maintenance/<int:request_id>")
+@login_required
+@tenant_required
+def maintenance_detail(request_id: int):
+    m = MaintenanceRequest.query.get_or_404(request_id)
+    if m.tenant_id != current_user.id:
+        return abort(404)
+    return render_template("tenant/maintenance_detail.html", m=m)
+
+
+@tenant_bp.route("/complaints/<int:complaint_id>")
+@login_required
+@tenant_required
+def complaint_detail(complaint_id: int):
+    c = Complaint.query.get_or_404(complaint_id)
+    if c.tenant_id != current_user.id:
+        return abort(404)
+    return render_template("tenant/complaint_detail.html", c=c)


### PR DESCRIPTION
Add detail pages for tenant maintenance requests and complaints to allow tenants to view their status and updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fdcaddc-93ba-4f0b-b953-d83d224cb4ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fdcaddc-93ba-4f0b-b953-d83d224cb4ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

