### PR TITLE
Create real estate page for employees and managers

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,9 +26,11 @@
             {% if current_user.role == 'admin' %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.dashboard') }}">{{ _('Admin') }}</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.users_list') }}">{{ _('Users') }}</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.properties_list') }}">{{ _('Properties') }}</a></li>
             {% endif %}
             {% if current_user.role == 'employee' %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.dashboard') }}">{{ _('Employee') }}</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.properties_list') }}">{{ _('Properties') }}</a></li>
             {% endif %}
             {% if current_user.role == 'tenant' %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('tenant.dashboard') }}">{{ _('Tenant') }}</a></li>


### PR DESCRIPTION
Add a "Properties" navigation link for both admin and employee roles.

This makes the existing `employee.properties_list` page accessible to both managers (admins) and employees, fulfilling the request to show the real estate page to both.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e0472c7-0a72-4dbb-851f-648028eced46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e0472c7-0a72-4dbb-851f-648028eced46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

