### PR TITLE
Add building details to real estate page

### DIFF
--- a/app/employee/routes.py
+++ b/app/employee/routes.py
@@ -59,6 +59,11 @@ def properties_create():
         title = request.form.get("title")
         price = request.form.get("price")
         description = request.form.get("description")
+        # Building fields (optional)
+        num_apartments_raw = (request.form.get("num_apartments") or "").strip()
+        num_floors_raw = (request.form.get("num_floors") or "").strip()
+        num_apartments = int(num_apartments_raw) if num_apartments_raw.isdigit() else None
+        num_floors = int(num_floors_raw) if num_floors_raw.isdigit() else None
         images_filenames = []
         images_files = request.files.getlist("images")
         upload_dir = os.path.join(current_app.config["UPLOAD_FOLDER"], "properties")
@@ -70,7 +75,15 @@ def properties_create():
                 f.save(path)
                 images_filenames.append(f"properties/{filename}")
         images_value = ",".join(images_filenames) if images_filenames else None
-        prop = Property(title=title, price=price, description=description, status="available", images=images_value)
+        prop = Property(
+            title=title,
+            price=price,
+            description=description,
+            status="available",
+            images=images_value,
+            num_apartments=num_apartments,
+            num_floors=num_floors,
+        )
         db.session.add(prop)
         db.session.commit()
         flash(_("Property created"), "success")
@@ -88,6 +101,11 @@ def properties_edit(prop_id: int):
         prop.price = request.form.get("price")
         prop.description = request.form.get("description")
         prop.status = request.form.get("status") or prop.status
+        # Building fields (optional)
+        num_apartments_raw = (request.form.get("num_apartments") or "").strip()
+        num_floors_raw = (request.form.get("num_floors") or "").strip()
+        prop.num_apartments = int(num_apartments_raw) if num_apartments_raw.isdigit() else None
+        prop.num_floors = int(num_floors_raw) if num_floors_raw.isdigit() else None
         images_files = request.files.getlist("images")
         if images_files:
             upload_dir = os.path.join(current_app.config["UPLOAD_FOLDER"], "properties")

--- a/app/models.py
+++ b/app/models.py
@@ -53,6 +53,9 @@ class Property(db.Model, TimestampMixin):
     price = db.Column(db.Numeric(12, 2), nullable=False, default=0)
     status = db.Column(db.String(50), nullable=False, default="available")
     images = db.Column(db.Text)  # store comma-separated file names or JSON
+    # Building-related metadata
+    num_apartments = db.Column(db.Integer, nullable=True)
+    num_floors = db.Column(db.Integer, nullable=True)
 
     contracts = db.relationship("Contract", back_populates="property", lazy="dynamic")
 

--- a/app/templates/employee/properties_list.html
+++ b/app/templates/employee/properties_list.html
@@ -3,7 +3,10 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
   <h3>{{ _('Properties') }}</h3>
-  <a class="btn btn-primary" href="{{ url_for('employee.properties_create') }}">{{ _('Add Property') }}</a>
+  <div class="btn-group">
+    <a class="btn btn-primary" href="{{ url_for('employee.properties_create') }}">{{ _('Add Property') }}</a>
+    <button class="btn btn-outline-primary" type="button" data-bs-toggle="modal" data-bs-target="#addBuildingModal">{{ _('Add Building') }}</button>
+  </div>
   </div>
 <table class="table table-striped">
   <thead><tr><th>#</th><th>{{ _('Title') }}</th><th>{{ _('Price') }}</th><th>{{ _('Status') }}</th><th></th></tr></thead>
@@ -28,4 +31,50 @@
     {% endfor %}
   </tbody>
 </table>
+
+<!-- Add Building Modal -->
+<div class="modal fade" id="addBuildingModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('employee.properties_create') }}" enctype="multipart/form-data">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ _('Add Building') }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">{{ _('Title') }}</label>
+            <input class="form-control" name="title" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ _('Price') }}</label>
+            <input class="form-control" name="price" type="number" step="0.01" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ _('Description') }}</label>
+            <textarea class="form-control" rows="3" name="description"></textarea>
+          </div>
+          <div class="row">
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">{{ _('Number of apartments') }}</label>
+                <input class="form-control" name="num_apartments" type="number" min="0" step="1" />
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="mb-3">
+                <label class="form-label">{{ _('Number of floors') }}</label>
+                <input class="form-control" name="num_floors" type="number" min="0" step="1" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Cancel') }}</button>
+          <button type="submit" class="btn btn-primary">{{ _('Create Property') }}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/app/templates/employee/property_form.html
+++ b/app/templates/employee/property_form.html
@@ -15,6 +15,20 @@
     <label class="form-label">{{ _('Description') }}</label>
     <textarea class="form-control" rows="4" name="description">{{ property.description if property else '' }}</textarea>
   </div>
+  <div class="row">
+    <div class="col-md-6">
+      <div class="mb-3">
+        <label class="form-label">{{ _('Number of apartments') }}</label>
+        <input class="form-control" name="num_apartments" type="number" min="0" step="1" value="{{ property.num_apartments if property and property.num_apartments is not none else '' }}" />
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="mb-3">
+        <label class="form-label">{{ _('Number of floors') }}</label>
+        <input class="form-control" name="num_floors" type="number" min="0" step="1" value="{{ property.num_floors if property and property.num_floors is not none else '' }}" />
+      </div>
+    </div>
+  </div>
   {% if property %}
   <div class="mb-3">
     <label class="form-label">{{ _('Status') }}</label>

--- a/app/translations/ar/LC_MESSAGES/messages.po
+++ b/app/translations/ar/LC_MESSAGES/messages.po
@@ -277,6 +277,15 @@ msgstr "تصدير إكسل"
 msgid "Export PDF"
 msgstr "تصدير PDF"
 
+msgid "Add Building"
+msgstr "إضافة مبنى"
+
+msgid "Number of apartments"
+msgstr "عدد الشقق"
+
+msgid "Number of floors"
+msgstr "عدد الأدوار"
+
 msgid "Maintenance Request"
 msgstr "طلب صيانة"
 

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -145,3 +145,12 @@ msgstr "Toggle"
 
 msgid "Payment status updated"
 msgstr "Payment status updated"
+
+msgid "Add Building"
+msgstr "Add Building"
+
+msgid "Number of apartments"
+msgstr "Number of apartments"
+
+msgid "Number of floors"
+msgstr "Number of floors"

--- a/migrations/versions/2bf1a9a0f9b4_add_building_fields_to_properties.py
+++ b/migrations/versions/2bf1a9a0f9b4_add_building_fields_to_properties.py
@@ -1,0 +1,24 @@
+"""add building fields to properties
+
+Revision ID: 2bf1a9a0f9b4
+Revises: 
+Create Date: 2025-10-02 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '2bf1a9a0f9b4'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:\n    op.add_column('properties', sa.Column('num_apartments', sa.Integer(), nullable=True))
+    op.add_column('properties', sa.Column('num_floors', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('properties', 'num_floors')
+    op.drop_column('properties', 'num_apartments')


### PR DESCRIPTION
Add 'Add Building' button and modal to the properties page to capture number of apartments and floors for new properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4fb0740-57fe-48c1-96da-9dfd1a5511a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4fb0740-57fe-48c1-96da-9dfd1a5511a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

