### PR TITLE
Shorten notification display time

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -60,12 +60,27 @@
       {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
       {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
+      <div class="alert alert-{{ category }} fade show" role="alert">{{ message }}</div>
       {% endfor %}
       {% endif %}
       {% endwith %}
       {% block content %}{% endblock %}
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const alerts = document.querySelectorAll('.alert');
+        alerts.forEach(function (el) {
+          setTimeout(function () {
+            try {
+              const instance = bootstrap.Alert.getOrCreateInstance(el);
+              instance.close();
+            } catch (e) {
+              el.style.display = 'none';
+            }
+          }, 1000);
+        });
+      });
+    </script>
   </body>
   </html>


### PR DESCRIPTION
Shorten flash message display duration to 1 second as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-18b4180b-e2a4-45f9-8f0f-dbc4bd9c3658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18b4180b-e2a4-45f9-8f0f-dbc4bd9c3658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

