### PR TITLE
Show unrented properties on manager dashboard

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -38,10 +38,11 @@
 
 <div class="row g-3 mt-1">
   <div class="col-12 col-md-6">
-    <div class="card h-100">
+    <div class="card h-100 position-relative">
       <div class="card-body">
         <div class="text-muted small mb-1">{{ _('Unleased Properties') }}</div>
         <div class="fs-3 fw-semibold">{{ unleased_properties }}</div>
+        <a class="stretched-link" href="{{ url_for('employee.properties_list', only='unleased') }}" aria-label="{{ _('Unleased Properties') }}"></a>
       </div>
     </div>
   </div>

--- a/app/templates/employee/properties_list.html
+++ b/app/templates/employee/properties_list.html
@@ -9,6 +9,13 @@
   </div>
 </div>
 
+{% if only == 'unleased' %}
+<div class="alert alert-info d-flex justify-content-between align-items-center">
+  <div>{{ _('Filtered to unleased properties') }}</div>
+  <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('employee.properties_list') }}">{{ _('Clear filter') }}</a>
+  </div>
+{% endif %}
+
 <h5 class="mt-3">{{ _('Buildings') }}</h5>
 <table class="table table-striped">
   <thead><tr><th>#</th><th>{{ _('Title') }}</th><th>{{ _('Price') }}</th><th>{{ _('Status') }}</th><th></th></tr></thead>

--- a/app/translations/ar/LC_MESSAGES/messages.po
+++ b/app/translations/ar/LC_MESSAGES/messages.po
@@ -265,6 +265,13 @@ msgstr "عقارات غير مؤجرة"
 msgid "Maintenance Requests > 24h"
 msgstr "طلبات صيانة لأكثر من 24 ساعة"
 
+# Filtering labels
+msgid "Filtered to unleased properties"
+msgstr "مصفاة لعرض العقارات غير المؤجرة"
+
+msgid "Clear filter"
+msgstr "إزالة التصفية"
+
 msgid "Generate Invoice"
 msgstr "إنشاء فاتورة"
 


### PR DESCRIPTION
Add a link on the admin dashboard's "Unleased Properties" card to filter the properties list to only show unleased properties.

This allows managers to quickly access a filtered list of unleased properties directly from the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bbda1eb-f46b-410e-aaa1-986151bd9de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bbda1eb-f46b-410e-aaa1-986151bd9de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

