### PR TITLE
Add contract upload with person and property

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ class Config:
     SQLALCHEMY_DATABASE_URI = f"sqlite:///{os.path.join(basedir, 'instance', 'app.db')}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
-    ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
+    ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'pdf'}
     MAX_CONTENT_LENGTH = 25 * 1024 * 1024  # 25 MB
     LANGUAGES = {"en": "English", "ar": "العربية"}
     BABEL_DEFAULT_LOCALE = "en"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -32,6 +32,7 @@
             {% if current_user.role == 'employee' %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.dashboard') }}">{{ _('Employee') }}</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.properties_list') }}">{{ _('Properties') }}</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.contracts_list') }}">{{ _('Contracts') }}</a></li>
             {% endif %}
             {% if current_user.role == 'tenant' %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('tenant.dashboard') }}">{{ _('Tenant') }}</a></li>

--- a/app/templates/employee/contracts_list.html
+++ b/app/templates/employee/contracts_list.html
@@ -41,6 +41,7 @@
         <th>{{ _('End') }}</th>
         <th>{{ _('Rent') }}</th>
         <th>{{ _('Status') }}</th>
+        <th>{{ _('Document') }}</th>
       </tr>
     </thead>
     <tbody>
@@ -63,10 +64,19 @@
             <span class="badge bg-secondary">{{ c.status }}</span>
           {% endif %}
         </td>
+        <td>
+          {% if c.document_path %}
+          <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('uploaded_file', filename=c.document_path) }}" target="_blank">
+            <i class="bi bi-box-arrow-up-right me-1"></i>{{ _('View') }}
+          </a>
+          {% else %}
+          <span class="text-muted">—</span>
+          {% endif %}
+        </td>
       </tr>
       {% else %}
       <tr>
-        <td colspan="7" class="text-center py-4">{{ _('No data') }}</td>
+        <td colspan="8" class="text-center py-4">{{ _('No data') }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Add contract document upload functionality for employees, supporting image and PDF files, with improved display and server-side validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0923d71f-bd60-49dc-8ded-9feb8961fd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0923d71f-bd60-49dc-8ded-9feb8961fd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

