### PR TITLE
Display building apartments with image cards

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -21,3 +21,55 @@ html[dir="rtl"] table td { text-align: right; }
 
 /* Typography polish for share page */
 .lead.text-body-secondary { line-height: 1.7; }
+
+/* --- Shared property/apartment card grid --- */
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.property-card {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8f9fa;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+  transition: 0.2s;
+}
+
+.property-card:active {
+  transform: scale(0.97);
+}
+
+.property-card img {
+  width: 100%;
+  aspect-ratio: 1 / 1; /* square */
+  object-fit: cover;
+  display: block;
+}
+
+.property-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 8px;
+  background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.property-status {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.status-available { background: #198754; }
+.status-occupied { background: #ffc107; color: #000; }
+.status-other { background: #6c757d; }

--- a/app/templates/employee/apartments_list.html
+++ b/app/templates/employee/apartments_list.html
@@ -2,16 +2,21 @@
 {% block title %}{{ building.title }}{% endblock %}
 
 {% block content %}
-<h4 class="mb-3"><i class="bi bi-house-door me-2"></i>{{ building.title }} - {{ _('Apartments') }}</h4>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0"><i class="bi bi-house-door me-2"></i>{{ building.title }} - {{ _('Apartments') }}</h4>
+  <a href="{{ url_for('employee.apartments_create', building_id=building.id) }}" class="btn btn-primary btn-sm">
+    <i class="bi bi-plus-circle me-1"></i>{{ _('Add Apartment') }}
+  </a>
+</div>
 
 <div class="grid-container">
   {% for a in apartments %}
-  <a href="{{ url_for('employee.apartments_list', building_id=building.id) }}" class="text-decoration-none">
-
+  {% set first_image = (a.images or '').split(',')[0] %}
+  <a href="{{ url_for('employee.apartments_edit', apt_id=a.id) }}" class="text-decoration-none">
     <div class="property-card">
-      <img src="{{ a.image_url or url_for('static', filename='default-apartment.jpg') }}" alt="{{ a.title }}">
+      <img src="{{ first_image and url_for('uploaded_file', filename=first_image) or url_for('static', filename='default-apartment.jpg') }}" alt="{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}">
       <div class="property-info">
-        <span>{{ a.title }}</span>
+        <span>{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}</span>
         {% if a.status == 'available' %}
           <span class="property-status status-available">{{ _('Available') }}</span>
         {% elif a.status == 'occupied' %}

--- a/app/templates/employee/properties_list.html
+++ b/app/templates/employee/properties_list.html
@@ -3,59 +3,6 @@
 
 {% block content %}
 
-<style>
-/* شبكة الصور */
-.grid-container {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-}
-
-/* الكارت */
-.property-card {
-  position: relative;
-  border-radius: 12px;
-  overflow: hidden;
-  background: #f8f9fa;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.08);
-  transition: 0.2s;
-}
-.property-card:active {
-  transform: scale(0.97);
-}
-
-/* الصورة */
-.property-card img {
-  width: 100%;
-  aspect-ratio: 1 / 1; /* مربع */
-  object-fit: cover;
-}
-
-/* العنوان فوق الصورة */
-.property-info {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 8px;
-  background: linear-gradient(to top, rgba(0,0,0,0.7), transparent);
-  color: #fff;
-  font-weight: 600;
-  font-size: 0.95rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.property-status {
-  font-size: 0.75rem;
-  padding: 2px 6px;
-  border-radius: 6px;
-}
-.status-available { background: #198754; }
-.status-occupied { background: #ffc107; color: #000; }
-.status-other { background: #6c757d; }
-</style>
-
 <!-- عنوان -->
 <!-- عنوان + زر إضافة -->
 <div class="d-flex justify-content-between align-items-center mb-3">


### PR DESCRIPTION
Refactor property/apartment card styles into a global stylesheet and update the apartments list page to display apartments as clickable image cards, matching the properties page UI.

This change implements the user's request to have a consistent visual experience for viewing buildings and apartments. The shared card styling is now centralized, and the apartments page correctly displays apartments as image cards with appropriate links and details.

---
<a href="https://cursor.com/background-agent?bcId=bc-84160709-61ae-4afd-93ff-c8ccf6a96c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84160709-61ae-4afd-93ff-c8ccf6a96c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

