### PR TITLE
Link dashboard cards and buttons

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -52,8 +52,11 @@
     <a class="btn btn-light btn-sm me-2" href="{{ url_for('admin.create_user', role='employee') }}">
       <i class="bi bi-person-plus"></i> {{ _('Add Employee') }}
     </a>
-    <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin.create_user', role='tenant') }}">
+    <a class="btn btn-outline-light btn-sm me-2" href="{{ url_for('admin.create_user', role='tenant') }}">
       <i class="bi bi-person-plus-fill"></i> {{ _('Add Tenant') }}
+    </a>
+    <a class="btn btn-outline-light btn-sm" href="{{ url_for('admin.users_list') }}">
+      <i class="bi bi-people"></i> {{ _('Manage Users') }}
     </a>
   </div>
 </div>

--- a/app/templates/employee/dashboard.html
+++ b/app/templates/employee/dashboard.html
@@ -30,11 +30,21 @@
   <!-- Recent Properties -->
   <div class="col-md-6">
     <div class="card-section">
-      <h5><i class="bi bi-building me-1"></i>{{ _('Recent Properties') }}</h5>
+      <div class="d-flex justify-content-between align-items-center">
+        <h5><i class="bi bi-building me-1"></i>{{ _('Recent Properties') }}</h5>
+        <div>
+          <a class="btn btn-sm btn-outline-primary me-2" href="{{ url_for('employee.properties_list') }}">{{ _('View All') }}</a>
+          <a class="btn btn-sm btn-primary" href="{{ url_for('employee.properties_create') }}">{{ _('Add') }}</a>
+        </div>
+      </div>
       <ul class="list-group mt-2">
         {% for p in properties %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
-          {{ p.title }}
+          {% if p.property_type == 'building' %}
+            <a class="text-decoration-none" href="{{ url_for('employee.apartments_list', building_id=p.id) }}">{{ p.title }}</a>
+          {% else %}
+            <a class="text-decoration-none" href="{{ url_for('employee.properties_edit', prop_id=p.id) }}">{{ p.title }}</a>
+          {% endif %}
           {% if p.status == 'available' %}
             <span class="badge bg-success badge-status">{{ _('Available') }}</span>
           {% elif p.status == 'occupied' %}
@@ -55,11 +65,17 @@
   <!-- Recent Contracts -->
   <div class="col-md-6">
     <div class="card-section">
-      <h5><i class="bi bi-file-text me-1"></i>{{ _('Recent Contracts') }}</h5>
+      <div class="d-flex justify-content-between align-items-center">
+        <h5><i class="bi bi-file-text me-1"></i>{{ _('Recent Contracts') }}</h5>
+        <div>
+          <a class="btn btn-sm btn-outline-primary me-2" href="{{ url_for('employee.contracts_list') }}">{{ _('View All') }}</a>
+          <a class="btn btn-sm btn-primary" href="{{ url_for('employee.contracts_create') }}">{{ _('Add') }}</a>
+        </div>
+      </div>
       <ul class="list-group mt-2">
         {% for c in contracts %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
-          #{{ c.id }}
+          <a class="text-decoration-none" href="{{ url_for('employee.contracts_list') }}">#{{ c.id }}</a>
           {% if c.status == 'active' %}
             <span class="badge bg-success badge-status">{{ _('Active') }}</span>
           {% elif c.status == 'expired' %}


### PR DESCRIPTION
Link all cards and buttons in `dashboard.html` to their intended destination pages.

This PR improves navigation by adding "View All" and "Add" buttons for Properties and Contracts in the employee dashboard, making property titles and contract IDs clickable, and adding a "Manage Users" button in the admin dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2d5fba1-092b-483a-87a1-2af34b5b4808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2d5fba1-092b-483a-87a1-2af34b5b4808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

