### PR TITLE
Navigate admin dashboard to property and tenant views

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -92,6 +92,10 @@ def dashboard():
             overdue_maintenance_24h = res.scalar() or 0
     except Exception:
         overdue_maintenance_24h = 0
+    # Basic counts for employees and tenants
+    total_employees = User.query.filter_by(role="employee").count()
+    total_tenants = User.query.filter_by(role="tenant").count()
+
     return render_template(
         "admin/dashboard.html",
         properties_count=properties_count,
@@ -101,6 +105,8 @@ def dashboard():
         profit=profit,
         unleased_properties=unleased_properties,
         overdue_maintenance_24h=overdue_maintenance_24h,
+        total_employees=total_employees,
+        total_tenants=total_tenants,
     )
 
 
@@ -109,8 +115,12 @@ def dashboard():
 @admin_required
 def users_list():
     from ..models import User
-
-    users = User.query.order_by(User.created_at.desc()).all()
+    # Optional role filter via query string, e.g., /admin/users?role=tenant
+    role = (request.args.get("role") or "").strip().lower()
+    query = User.query
+    if role in {"employee", "tenant", "accountant", "admin"}:
+        query = query.filter_by(role=role)
+    users = query.order_by(User.created_at.desc()).all()
     return render_template("admin/users_list.html", users=users)
 
 

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -28,6 +28,13 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.15);
 }
 
+/* روابط الكروت لتكون قابلة للنقر بدون تغيير الشكل */
+a.stat-card-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
 .stat-card i {
   font-size: 2.5rem;
   margin-bottom: 10px;
@@ -67,11 +74,13 @@
     <span>{{ _('Profit') }}</span>
     <span>{{ profit }}</span>
   </div>
-  <div class="stat-card bg-house">
-    <i class="bi bi-house-door"></i>
-    <span>{{ _('Unleased Properties') }}</span>
-    <span>{{ unleased_properties }}</span>
-  </div>
+  <a href="{{ url_for('employee.properties_list', only='unleased') }}" class="stat-card-link">
+    <div class="stat-card bg-house">
+      <i class="bi bi-house-door"></i>
+      <span>{{ _('Unleased Properties') }}</span>
+      <span>{{ unleased_properties }}</span>
+    </div>
+  </a>
   <div class="stat-card bg-maint">
     <i class="bi bi-tools"></i>
     <span>{{ _('Maintenance >24h') }}</span>
@@ -82,11 +91,13 @@
     <span>{{ _('Employees') }}</span>
     <span>{{ total_employees }}</span>
   </div>
-  <div class="stat-card bg-tenant">
-    <i class="bi bi-people"></i>
-    <span>{{ _('Tenants') }}</span>
-    <span>{{ total_tenants }}</span>
-  </div>
+  <a href="{{ url_for('admin.users_list', role='tenant') }}" class="stat-card-link">
+    <div class="stat-card bg-tenant">
+      <i class="bi bi-people"></i>
+      <span>{{ _('Tenants') }}</span>
+      <span>{{ total_tenants }}</span>
+    </div>
+  </a>
 </div>
 
 <!-- أحدث الشكاوى والصيانات -->


### PR DESCRIPTION
Make "Unleased Properties" and "Tenants" dashboard cards clickable to navigate to their respective filtered lists.

---
<a href="https://cursor.com/background-agent?bcId=bc-eff53045-0a23-44e8-9be9-2974c51a33e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eff53045-0a23-44e8-9be9-2974c51a33e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

