### PR TITLE
Link employee dashboard to cards

### DIFF
--- a/app/employee/routes.py
+++ b/app/employee/routes.py
@@ -41,6 +41,22 @@ def dashboard():
     )
 
 
+@employee_bp.route("/maintenance")
+@login_required
+@employee_required
+def maintenance_list():
+    maints = MaintenanceRequest.query.order_by(MaintenanceRequest.created_at.desc()).all()
+    return render_template("employee/maintenance_list.html", maintenance_requests=maints)
+
+
+@employee_bp.route("/complaints")
+@login_required
+@employee_required
+def complaints_list():
+    complaints = Complaint.query.order_by(Complaint.created_at.desc()).all()
+    return render_template("employee/complaints_list.html", complaints=complaints)
+
+
 @employee_bp.route("/properties")
 @login_required
 @employee_required

--- a/app/templates/employee/complaints_list.html
+++ b/app/templates/employee/complaints_list.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Complaints') }}{% endblock %}
+
+{% block content %}
+<style>
+.table tbody tr:hover { background-color: #f8f9fa; }
+.badge-status { font-size: 0.8rem; }
+.bg-new { background: #0d6efd; color: #fff; }
+.bg-reviewing { background: #ffc107; color: #212529; }
+.bg-resolved { background: #198754; color: #fff; }
+.bg-closed { background: #6c757d; color: #fff; }
+</style>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3><i class="bi bi-exclamation-triangle me-2"></i>{{ _('Complaints') }}</h3>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-hover align-middle">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>{{ _('Subject') }}</th>
+        <th>{{ _('Description') }}</th>
+        <th>{{ _('Status') }}</th>
+        <th>{{ _('Created at') }}</th>
+        <th>{{ _('Actions') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in complaints %}
+      <tr>
+        <td>{{ c.id }}</td>
+        <td>{{ c.subject }}</td>
+        <td class="text-truncate" style="max-width: 320px;">{{ c.description }}</td>
+        <td><span class="badge badge-status bg-{{ c.status }}">{{ c.status }}</span></td>
+        <td>{{ c.created_at }}</td>
+        <td>
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('employee.complaint_update', comp_id=c.id) }}">
+            <i class="bi bi-pencil-square me-1"></i>{{ _('Update') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="6" class="text-center py-4">{{ _('No complaints') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/app/templates/employee/dashboard.html
+++ b/app/templates/employee/dashboard.html
@@ -59,25 +59,25 @@
 
 <!-- كروت رئيسية لكل قسم -->
 <div class="dashboard-grid">
-  <div class="dashboard-card">
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.properties_list') }}'">
     <i class="bi bi-building"></i>
     <span>{{ _('Properties') }}</span>
     <span class="badge-status">{{ properties|length }}</span>
   </div>
 
-  <div class="dashboard-card">
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.contracts_list') }}'">
     <i class="bi bi-file-text"></i>
     <span>{{ _('Contracts') }}</span>
     <span class="badge-status">{{ contracts|length }}</span>
   </div>
 
-  <div class="dashboard-card">
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.maintenance_list') }}'">
     <i class="bi bi-tools"></i>
     <span>{{ _('Maintenance Requests') }}</span>
     <span class="badge-status">{{ maintenance_requests|length }}</span>
   </div>
 
-  <div class="dashboard-card">
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.complaints_list') }}'">
     <i class="bi bi-exclamation-triangle"></i>
     <span>{{ _('Complaints') }}</span>
     <span class="badge-status">{{ complaints|length }}</span>
@@ -88,7 +88,7 @@
 <h5 class="mt-4 mb-2"><i class="bi bi-building me-1"></i>{{ _('Recent Properties') }}</h5>
 <div class="dashboard-grid">
   {% for p in properties[:6] %}
-  <div class="dashboard-card">
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.properties_edit', prop_id=p.id) }}'">
     <i class="bi bi-house-door"></i>
     <span>{{ p.title }}</span>
     {% if p.status == 'available' %}

--- a/app/templates/employee/maintenance_list.html
+++ b/app/templates/employee/maintenance_list.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Maintenance Requests') }}{% endblock %}
+
+{% block content %}
+<style>
+.table tbody tr:hover { background-color: #f8f9fa; }
+.badge-status { font-size: 0.8rem; }
+.bg-new { background: #0d6efd; color: #fff; }
+.bg-in_progress { background: #ffc107; color: #212529; }
+.bg-resolved { background: #198754; color: #fff; }
+.bg-closed { background: #6c757d; color: #fff; }
+</style>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3><i class="bi bi-tools me-2"></i>{{ _('Maintenance Requests') }}</h3>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-hover align-middle">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>{{ _('Title') }}</th>
+        <th>{{ _('Description') }}</th>
+        <th>{{ _('Status') }}</th>
+        <th>{{ _('Created at') }}</th>
+        <th>{{ _('Actions') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for m in maintenance_requests %}
+      <tr>
+        <td>{{ m.id }}</td>
+        <td>{{ m.title }}</td>
+        <td class="text-truncate" style="max-width: 320px;">{{ m.description }}</td>
+        <td><span class="badge badge-status bg-{{ m.status }}">{{ m.status }}</span></td>
+        <td>{{ m.created_at }}</td>
+        <td>
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('employee.maintenance_update', req_id=m.id) }}">
+            <i class="bi bi-pencil-square me-1"></i>{{ _('Update') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="6" class="text-center py-4">{{ _('No maintenance requests') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
Add routes and templates for maintenance and complaints lists, and link employee dashboard cards to their respective pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f68285a-4dbf-4ed6-82c2-c1726db1b050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f68285a-4dbf-4ed6-82c2-c1726db1b050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

