### PR TITLE
Copy share link to clipboard directly

### DIFF
--- a/app/employee/routes.py
+++ b/app/employee/routes.py
@@ -229,15 +229,12 @@ def properties_edit(prop_id: int):
     return render_template("employee/property_form.html", property=prop)
 
 
-@employee_bp.route("/properties/<int:prop_id>/share", methods=["GET"])  # simple redirect to public link
+@employee_bp.route("/properties/<int:prop_id>/share", methods=["GET"])  # kept for backward compatibility
 @login_required
 @employee_required
 def properties_share(prop_id: int):
-    prop = Property.query.get_or_404(prop_id)
-    serializer = URLSafeSerializer(current_app.config["SECRET_KEY"], salt="property-share")
-    token = serializer.dumps(prop.id)
-    public_url = url_for("public_property_view", token=token, _external=True)
-    flash(_("Share link generated: ") + public_url, "info")
+    # No longer displays the URL; just informs that copying is available via the list page
+    flash(_("Use the Share button to copy the link"), "info")
     return redirect(url_for("employee.properties_list"))
 
 

--- a/app/templates/employee/properties_list.html
+++ b/app/templates/employee/properties_list.html
@@ -78,9 +78,9 @@
       </div>
     </a>
     <div class="property-actions">
-      <a href="{{ url_for('employee.properties_share', prop_id=b.id) }}" class="btn btn-outline-secondary btn-sm">
-        <i class="bi bi-share me-1"></i>{{ _('Share') }}
-      </a>
+      <button type="button" class="btn btn-outline-secondary btn-sm"
+        onclick="navigator.clipboard.writeText('{{ url_for('public_property_view', token=share_tokens[b.id], _external=True) }}'); this.innerHTML='<i class=&quot;bi bi-clipboard-check me-1&quot;></i>{{ _('Copied') }}'; setTimeout(()=>{ this.innerHTML='<i class=&quot;bi bi-share me-1&quot;></i>{{ _('Share') }}'; }, 1500);">
+        <i class="bi bi-share me-1"></i>{{ _('Share') }}</button>
       <form method="post" action="{{ url_for('employee.properties_delete', prop_id=b.id) }}" class="d-inline" onsubmit="return confirm('{{ _('Are you sure you want to delete this property?') }}');">
         <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash me-1"></i>{{ _('Delete') }}</button>
       </form>
@@ -114,9 +114,9 @@
       </div>
     </a>
     <div class="property-actions">
-      <a href="{{ url_for('employee.properties_share', prop_id=a.id) }}" class="btn btn-outline-secondary btn-sm">
-        <i class="bi bi-share me-1"></i>{{ _('Share') }}
-      </a>
+      <button type="button" class="btn btn-outline-secondary btn-sm"
+        onclick="navigator.clipboard.writeText('{{ url_for('public_property_view', token=share_tokens[a.id], _external=True) }}'); this.innerHTML='<i class=&quot;bi bi-clipboard-check me-1&quot;></i>{{ _('Copied') }}'; setTimeout(()=>{ this.innerHTML='<i class=&quot;bi bi-share me-1&quot;></i>{{ _('Share') }}'; }, 1500);">
+        <i class="bi bi-share me-1"></i>{{ _('Share') }}</button>
       <form method="post" action="{{ url_for('employee.properties_delete', prop_id=a.id) }}" class="d-inline" onsubmit="return confirm('{{ _('Are you sure you want to delete this property?') }}');">
         <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash me-1"></i>{{ _('Delete') }}</button>
       </form>


### PR DESCRIPTION
Update the share button to copy the public property link directly to the clipboard without displaying it.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c8a5ee6-8083-413c-b0b6-79a7af4a7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c8a5ee6-8083-413c-b0b6-79a7af4a7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

