### PR TITLE
Add paid button for rent income

### DIFF
--- a/app/templates/admin/users_list.html
+++ b/app/templates/admin/users_list.html
@@ -61,6 +61,7 @@
             <th>{{ _('Email') }}</th>
             <th>{{ _('Role') }}</th>
             <th>{{ _('Created') }}</th>
+            <th>{{ _('Actions') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -71,10 +72,19 @@
             <td>{{ u.email }}</td>
             <td>{{ u.role|capitalize }}</td>
             <td>{{ u.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>
+              {% if u.role == 'tenant' %}
+              <form action="{{ url_for('employee.collect_rent', tenant_id=u.id) }}" method="post" class="d-inline">
+                <button class="btn btn-sm btn-success" type="submit">{{ _('Mark as Paid') }}</button>
+              </form>
+              {% else %}
+              <span class="text-muted">—</span>
+              {% endif %}
+            </td>
           </tr>
           {% else %}
           <tr>
-            <td colspan="5" class="text-center py-4">{{ _('No data') }}</td>
+            <td colspan="6" class="text-center py-4">{{ _('No data') }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/employee/dashboard.html
+++ b/app/templates/employee/dashboard.html
@@ -71,6 +71,11 @@
     <span class="badge-status">{{ contracts|length }}</span>
   </div>
 
+  <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.rent_collection_list') }}'">
+    <i class="bi bi-cash-coin"></i>
+    <span>{{ _('Rent Collection') }}</span>
+  </div>
+
   <div class="dashboard-card" onclick="window.location.href='{{ url_for('employee.maintenance_list') }}'">
     <i class="bi bi-tools"></i>
     <span>{{ _('Maintenance Requests') }}</span>

--- a/app/templates/employee/rent_collection.html
+++ b/app/templates/employee/rent_collection.html
@@ -1,0 +1,98 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Rent Collection') }}{% endblock %}
+
+{% block content %}
+<style>
+.table thead th { background-color: #f8f9fa; font-weight: 600; }
+.table tbody tr:hover { background-color: #f1f5f9; }
+.badge-status { padding: 6px 10px; border-radius: 10px; font-size: 0.8rem; font-weight: 600; }
+.bg-paid { background: #198754; color: #fff; }
+.bg-unpaid { background: #ffc107; color: #212529; }
+.bg-nocontract { background: #6c757d; color: #fff; }
+</style>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3><i class="bi bi-cash-coin me-2"></i>{{ _('Rent Collection') }}</h3>
+  <div class="text-muted small">
+    {{ _('Month starting') }}: {{ month_start }}
+  </div>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped table-hover align-middle">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>{{ _('Tenant') }}</th>
+        <th>{{ _('Contract') }}</th>
+        <th>{{ _('Property') }}</th>
+        <th>{{ _('Rent Amount') }}</th>
+        <th>{{ _('This Month') }}</th>
+        <th>{{ _('Action') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      {% set t = row.tenant %}
+      {% set c = row.contract %}
+      <tr>
+        <td>{{ loop.index }}</td>
+        <td>
+          <div class="fw-semibold">{{ t.username }}</div>
+          <div class="text-muted small">{{ t.email }}</div>
+        </td>
+        <td>
+          {% if c %}
+            <span class="badge bg-success">{{ _('Active') }}</span>
+          {% else %}
+            <span class="badge bg-secondary">{{ _('None') }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if c %}
+            {{ c.property.title }}
+          {% else %}
+            <span class="text-muted">—</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if c %}
+            {{ c.rent_amount }}
+          {% else %}
+            <span class="text-muted">—</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if c %}
+            {% if row.paid_this_month %}
+              <span class="badge-status bg-paid">{{ _('Paid') }}</span>
+            {% else %}
+              <span class="badge-status bg-unpaid">{{ _('Unpaid') }}</span>
+            {% endif %}
+          {% else %}
+            <span class="badge-status bg-nocontract">{{ _('No contract') }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if c and not row.paid_this_month %}
+            <form action="{{ url_for('employee.collect_rent', tenant_id=t.id) }}" method="post" class="d-inline">
+              <button class="btn btn-sm btn-success" type="submit">
+                {{ _('Mark as Paid') }}
+              </button>
+            </form>
+          {% elif row.paid_this_month %}
+            <button class="btn btn-sm btn-outline-success" type="button" disabled>{{ _('Paid') }}</button>
+          {% else %}
+            <button class="btn btn-sm btn-outline-secondary" type="button" disabled>{{ _('Unavailable') }}</button>
+          {% endif %}
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="7" class="text-center py-4">{{ _('No data') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
Add a "Mark as Paid" button to tenant lists and a dedicated rent collection page to easily record rent payments as income.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0eb118f-b908-4c66-8798-ec35a2279b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0eb118f-b908-4c66-8798-ec35a2279b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

