### PR TITLE
Update tenant details on new addition

### DIFF
--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -50,10 +50,17 @@
         <label class="form-label">{{ _('Username') }}</label>
         <input type="text" name="username" class="form-control" value="{{ username_value|default('') }}" required />
       </div>
+      {% if role == 'tenant' %}
+      <div class="mb-3">
+        <label class="form-label">{{ _('Phone') }}</label>
+        <input type="tel" name="email" class="form-control" value="{{ email_value|default('') }}" required />
+      </div>
+      {% else %}
       <div class="mb-3">
         <label class="form-label">{{ _('Email') }}</label>
         <input type="email" name="email" class="form-control" value="{{ email_value|default('') }}" required />
       </div>
+      {% endif %}
       <div class="mb-3">
         <label class="form-label">{{ _('Password') }}</label>
         <input type="password" name="password" class="form-control" required />
@@ -70,6 +77,10 @@
           {% endfor %}
         </select>
         <div class="form-text">{{ _('Only properties without an active contract are listed.') }}</div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">{{ _('Rent Amount') }}</label>
+        <input type="number" name="rent_amount" class="form-control" step="0.01" min="0" value="{{ rent_amount_value|default('') }}" required />
       </div>
       {% endif %}
       <div class="d-flex gap-2 mt-3">


### PR DESCRIPTION
Replace email with phone number and add rent amount field for new tenant creation.

The user requested to use a phone number instead of an email and to specify a rent amount when adding a new tenant.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a4c8b75-e265-425e-a860-6be9dd4dcff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a4c8b75-e265-425e-a860-6be9dd4dcff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

