### PR TITLE
Fix add tenant building apartment number display

### DIFF
--- a/app/templates/admin/user_form.html
+++ b/app/templates/admin/user_form.html
@@ -130,7 +130,11 @@
         }
         apartmentSelect.appendChild(opt);
       }
-      // If an apartment is preselected or has just been selected, reflect its number
+      // If none preselected, auto-select the first available option
+      if (!apartmentSelect.value && apartmentSelect.options.length > 1) {
+        apartmentSelect.selectedIndex = 1;
+      }
+      // Reflect the selected apartment's number into the input (for convenience)
       const selectedOpt = apartmentSelect.options[apartmentSelect.selectedIndex];
       if (selectedOpt && selectedOpt.value && apartmentNumberInput) {
         apartmentNumberInput.value = selectedOpt.dataset.number || '';


### PR DESCRIPTION
Auto-select the first available apartment and populate its number in the "Add Tenant" form.

---
<a href="https://cursor.com/background-agent?bcId=bc-b71e1b6c-ce5d-4ce4-9ca5-f4bb930c0228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b71e1b6c-ce5d-4ce4-9ca5-f4bb930c0228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

