### PR TITLE
Show all properties on admin guest page

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -74,6 +74,13 @@ a.stat-card-link {
     <span>{{ _('Profit') }}</span>
     <span>{{ profit }}</span>
   </div>
+  <a href="{{ url_for('employee.properties_list') }}" class="stat-card-link">
+    <div class="stat-card bg-house">
+      <i class="bi bi-houses"></i>
+      <span>{{ _('All Properties') }}</span>
+      <span>{{ properties_count }}</span>
+    </div>
+  </a>
   <a href="{{ url_for('employee.properties_list', only='unleased') }}" class="stat-card-link">
     <div class="stat-card bg-house">
       <i class="bi bi-house-door"></i>

--- a/app/translations/ar/LC_MESSAGES/messages.po
+++ b/app/translations/ar/LC_MESSAGES/messages.po
@@ -357,3 +357,6 @@ msgstr "تم إنشاء الموظف بنجاح"
 
 msgid "Tenant created successfully"
 msgstr "تم إنشاء المستأجر بنجاح"
+
+msgid "All Properties"
+msgstr "كل العقارات"

--- a/app/translations/en/LC_MESSAGES/messages.po
+++ b/app/translations/en/LC_MESSAGES/messages.po
@@ -168,3 +168,6 @@ msgstr "Number of apartments"
 
 msgid "Number of floors"
 msgstr "Number of floors"
+
+msgid "All Properties"
+msgstr "All Properties"


### PR DESCRIPTION
Add an "All Properties" card to the admin dashboard to display the total property count and link to the full properties list.

---
<a href="https://cursor.com/background-agent?bcId=bc-733e4122-0eab-4414-8b0f-5959ea88b5fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-733e4122-0eab-4414-8b0f-5959ea88b5fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

