### PR TITLE
Fix database table creation error

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -177,6 +177,16 @@ def create_app(config_class: type = Config) -> Flask:
         except Exception:
             pass
 
+        # Ensure default tenant tables exist on first run (when no company bound)
+        # This prevents "no such table: users" before any migrations run
+        try:
+            from sqlalchemy import inspect as sa_inspect
+            inspector = sa_inspect(db.engines[None])  # ensure default engine exists
+            if not inspector.has_table('users'):
+                db.create_all()
+        except Exception:
+            pass
+
     # --- Public Share Route for Property Details ---
     def _get_property_share_serializer() -> URLSafeSerializer:
         secret_key = app.config.get("SECRET_KEY")


### PR DESCRIPTION
Auto-create default tenant tables on first run to prevent "no such table: users" errors.

This ensures the application can start successfully before any database migrations are explicitly run, by checking if the `users` table exists in the default tenant's database and creating all tables if it does not.

---
<a href="https://cursor.com/background-agent?bcId=bc-42ce5f1e-38e3-4ca7-bd2e-020df141b9c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42ce5f1e-38e3-4ca7-bd2e-020df141b9c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

