### PR TITLE
Get admin username and password

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,6 +105,7 @@ def create_app(config_class: type = Config) -> Flask:
         if not current_user.is_authenticated:
             return redirect(url_for("auth.login"))
         role_redirect = {
+            "superadmin": "superadmin.dashboard",
             "admin": "admin.dashboard",
             "employee": "employee.dashboard",
             "tenant": "tenant.dashboard",

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -16,7 +16,7 @@ def admin_required(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not current_user.is_authenticated or not current_user.is_admin:
+        if not current_user.is_authenticated or not (current_user.is_admin or current_user.is_superadmin):
             from flask import abort
 
             return abort(403)

--- a/app/cli.py
+++ b/app/cli.py
@@ -29,6 +29,24 @@ def register_cli(app: Flask) -> None:
         db.session.commit()
         click.echo("Admin created")
 
+    @app.cli.command("create-superadmin")
+    @click.option("--username", prompt=True)
+    @click.option("--email", prompt=True)
+    @click.option("--password", prompt=True, hide_input=True, confirmation_prompt=True)
+    def create_superadmin(username: str, email: str, password: str):
+        """Create a global superadmin user in the current (bound) tenant DB.
+
+        Note: Login routes automatically bind to a company DB. Ensure you have selected or are writing to the intended tenant DB when creating users.
+        """
+        if User.query.filter((User.username == username) | (User.email == email)).first():
+            click.echo("User with same username or email already exists")
+            return
+        user = User(username=username, email=email, role="superadmin")
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        click.echo("Superadmin created")
+
     @app.cli.command("seed-data")
     def seed_data():
         # Basic roles users

--- a/app/models.py
+++ b/app/models.py
@@ -34,6 +34,10 @@ class User(UserMixin, db.Model, TimestampMixin):
         return self.role == "admin"
 
     @property
+    def is_superadmin(self) -> bool:
+        return self.role == "superadmin"
+
+    @property
     def is_employee(self) -> bool:
         return self.role == "employee"
 

--- a/app/superadmin/routes.py
+++ b/app/superadmin/routes.py
@@ -17,7 +17,7 @@ def superadmin_required(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not current_user.is_authenticated or (current_user.role or "").lower() != "admin":
+        if not current_user.is_authenticated or not current_user.is_superadmin:
             from flask import abort
             return abort(403)
         return func(*args, **kwargs)


### PR DESCRIPTION
Implement a distinct 'superadmin' role with hierarchical access control to differentiate between global company management and single-company administration.

The user requested a clear separation of roles: one for managing sub-companies and another for managing a single company. This PR introduces a `superadmin` role with broader access (superadmin and admin areas) and restricts the `admin` role to company-specific administration, along with a CLI command to create superadmin users.

---
<a href="https://cursor.com/background-agent?bcId=bc-729ea9bc-24e4-4a90-9a93-c0d49dedd11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-729ea9bc-24e4-4a90-9a93-c0d49dedd11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

