### PR TITLE
Show all apartments on unrented properties page

### DIFF
--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -99,7 +99,7 @@ a.stat-card-link {
     </div>
   </a>
 
-  <a href="{{ url_for('employee.properties_list', only='unleased') }}" class="stat-card-link">
+  <a href="{{ url_for('admin.unleased_units') }}" class="stat-card-link">
     <div class="stat-card bg-unleased">
       <i class="bi bi-house-door"></i>
       <span>العقارات غير المؤجرة</span>

--- a/app/templates/admin/unleased_units.html
+++ b/app/templates/admin/unleased_units.html
@@ -1,0 +1,55 @@
+{% extends 'base.html' %}
+{% block title %}الوحدات غير المؤجرة{% endblock %}
+
+{% block content %}
+<style>
+.grid-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 14px; }
+.property-card { border-radius: 14px; overflow: hidden; box-shadow: 0 4px 14px rgba(0,0,0,0.08); background: #fff; transition: 0.3s ease; }
+.property-card:hover { transform: translateY(-5px); box-shadow: 0 8px 20px rgba(0,0,0,0.15); }
+.property-card img { width: 100%; aspect-ratio: 1 / 1; object-fit: cover; border-bottom: 3px solid #f8f9fa; }
+.property-info { display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; font-size: 0.95rem; }
+.property-status { font-weight: 600; }
+.status-available { color: #198754; }
+.section-title { color: #6f42c1; font-weight: bold; margin: 20px 0 12px; display: flex; align-items: center; gap: 6px; }
+.section-title i { font-size: 1.2rem; }
+.subtle { color: #6c757d; font-size: 0.9rem; }
+</style>
+
+<h3 class="mb-3 text-primary"><i class="bi bi-door-closed"></i> الوحدات غير المؤجرة</h3>
+
+<h5 class="section-title"><i class="bi bi-house"></i> شقق داخل المباني</h5>
+<div class="grid-container mb-4">
+  {% for a in building_apartments %}
+  {% set building = buildings_by_id.get(a.building_id) %}
+  <div class="property-card">
+    {% set first_image = (a.images or '').split(',')[0] %}
+    <img src="{{ first_image and url_for('uploaded_file', filename=first_image) or url_for('static', filename='default-apartment.jpg') }}" alt="{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}">
+    <div class="property-info">
+      <div>
+        <div>{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}</div>
+        <div class="subtle">{{ _('Building') }}: {{ building and building.title or ('#' ~ a.building_id) }}</div>
+      </div>
+      <span class="property-status status-available">{{ _('Available') }}</span>
+    </div>
+  </div>
+  {% else %}
+  <div class="col-12 text-center text-muted py-4">لا توجد شقق غير مؤجرة داخل المباني</div>
+  {% endfor %}
+</div>
+
+<h5 class="section-title"><i class="bi bi-house-door"></i> شقق مستقلة</h5>
+<div class="grid-container">
+  {% for p in standalone_apartments %}
+  <div class="property-card">
+    {% set first_p_image = (p.images or '').split(',')[0] %}
+    <img src="{{ first_p_image and url_for('uploaded_file', filename=first_p_image) or url_for('static', filename='default-apartment.jpg') }}" alt="{{ p.title }}">
+    <div class="property-info">
+      <span>{{ p.title }}</span>
+      <span class="property-status status-available">{{ _('Available') }}</span>
+    </div>
+  </div>
+  {% else %}
+  <div class="col-12 text-center text-muted py-4">لا توجد شقق مستقلة غير مؤجرة</div>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Create a dedicated admin page for unleased units to display both standalone apartments and apartments within buildings, providing a comprehensive view of all available units.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4f9b17c-9aa3-4b64-9b1f-de3bf85c602b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4f9b17c-9aa3-4b64-9b1f-de3bf85c602b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

