### PR TITLE
Fix rent amount showing zero on submit

### DIFF
--- a/app/templates/employee/rent_collection.html
+++ b/app/templates/employee/rent_collection.html
@@ -57,7 +57,19 @@
         </td>
         <td>
           {% if c %}
-            {{ c.rent_amount }}
+            {# Fallback to apartment or property price if contract.rent_amount is empty or zero #}
+            {% set ra = c.rent_amount %}
+            {% if not ra or ra == 0 %}
+              {% if c.apartment and c.apartment.rent_price %}
+                {{ c.apartment.rent_price }}
+              {% elif c.property and c.property.price %}
+                {{ c.property.price }}
+              {% else %}
+                0
+              {% endif %}
+            {% else %}
+              {{ ra }}
+            {% endif %}
           {% else %}
             <span class="text-muted">—</span>
           {% endif %}


### PR DESCRIPTION
Implement rent amount fallback logic in backend and UI to prevent displaying 0 when `contract.rent_amount` is missing or zero.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f2d13fd-ef02-4d43-8b7b-1779bed87e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f2d13fd-ef02-4d43-8b7b-1779bed87e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

