### PR TITLE
Display apartment images as square tiles

### DIFF
--- a/app/templates/employee/apartments_list.html
+++ b/app/templates/employee/apartments_list.html
@@ -41,9 +41,13 @@
 <div class="grid-container">
   {% for a in apartments %}
   {% set first_image = (a.images or '').split(',')[0] %}
+  {# Inline SVG placeholder for items without images #}
+  {% set placeholder_data = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Crect width='120' height='120' fill='%23f1f3f5'/%3E%3Cpath d='M20 70 L60 40 L100 70 V100 H75 V80 H45 V100 H20 Z' fill='%23adb5bd'/%3E%3C/svg%3E" %}
   <a href="{{ url_for('employee.apartments_edit', apt_id=a.id) }}" class="text-decoration-none">
     <div class="property-card">
-      <img src="{{ first_image and url_for('uploaded_file', filename=first_image) or url_for('static', filename='default-apartment.jpg') }}" alt="{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}">
+      <img src="{{ first_image and url_for('uploaded_file', filename=first_image) or placeholder_data }}"
+           alt="{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}"
+           onerror="this.onerror=null;this.src='{{ placeholder_data }}';">
       <div class="property-info">
         <span>{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}</span>
         {% if a.status == 'available' %}

--- a/app/templates/employee/properties_list.html
+++ b/app/templates/employee/properties_list.html
@@ -39,43 +39,35 @@
   </div>
   </form>
 
-<div class="table-responsive">
-  <table class="table table-striped table-hover align-middle">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>{{ _('Title') }}</th>
-        <th>{{ _('Type') }}</th>
-        <th>{{ _('Status') }}</th>
-        <th>{{ _('Created at') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for p in properties %}
-      <tr>
-        <td>{{ p.id }}</td>
-        <td>
-          <a href="{{ url_for('employee.properties_edit', prop_id=p.id) }}" class="text-decoration-none">{{ p.title }}</a>
-        </td>
-        <td>
-          {% if p.property_type == 'building' %}
-            <span class="badge text-bg-secondary">{{ _('Building') }}</span>
-          {% else %}
-            <span class="badge text-bg-info">{{ _('Apartment') }}</span>
-          {% endif %}
-        </td>
-        <td>
-          <span class="badge {{ 'text-bg-success' if p.status=='available' else 'text-bg-warning text-dark' if p.status=='occupied' else 'text-bg-secondary' }}">{{ p.status }}</span>
-        </td>
-        <td>{{ p.created_at }}</td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="5" class="text-center py-4">{{ _('No data') }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  </div>
+{# Inline SVG placeholder for items without images #}
+{% set placeholder_data = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Crect width='120' height='120' fill='%23f1f3f5'/%3E%3Cpath d='M20 70 L60 40 L100 70 V100 H75 V80 H45 V100 H20 Z' fill='%23adb5bd'/%3E%3C/svg%3E" %}
+
+<div class="grid-container">
+  {% for p in properties %}
+  {% set first_image = (p.images or '').split(',')[0] %}
+  {% set href_url = (p.property_type == 'building')
+                    and url_for('employee.apartments_list', building_id=p.id)
+                    or url_for('employee.properties_edit', prop_id=p.id) %}
+  <a href="{{ href_url }}" class="text-decoration-none">
+    <div class="property-card">
+      <img src="{{ first_image and url_for('uploaded_file', filename=first_image) or placeholder_data }}"
+           alt="{{ p.title }}"
+           onerror="this.onerror=null;this.src='{{ placeholder_data }}';" />
+      <div class="property-info">
+        <span>{{ p.title }}</span>
+        {% if p.status == 'available' %}
+          <span class="property-status status-available">{{ _('Available') }}</span>
+        {% elif p.status == 'occupied' %}
+          <span class="property-status status-occupied">{{ _('Occupied') }}</span>
+        {% else %}
+          <span class="property-status status-other">{{ p.status }}</span>
+        {% endif %}
+      </div>
+    </div>
+  </a>
+  {% else %}
+  <div class="col-12 text-center text-muted py-4">{{ _('No data') }}</div>
+  {% endfor %}
+</div>
 
 {% endblock %}


### PR DESCRIPTION
Display properties on the employee page as square image tiles and add robust SVG image placeholders.

Replaced the tabular display of properties with a responsive square-tile image grid on the employee properties page, and introduced an inline SVG placeholder for properties and apartments without images to ensure a consistent visual fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-952e6f71-f9e5-423f-a647-7408e7be0d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-952e6f71-f9e5-423f-a647-7408e7be0d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

