### PR TITLE
Add apartment sharing link for clients

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -104,7 +104,7 @@ def create_app(config_class: type = Config) -> Flask:
         except Exception:
             pass
 
-    # --- Public Share Route for Property Details ---
+    # --- Public Share Routes for Property and Apartment Details ---
     def _get_property_share_serializer() -> URLSafeSerializer:
         secret_key = app.config.get("SECRET_KEY")
         return URLSafeSerializer(secret_key, salt="property-share")
@@ -129,6 +129,35 @@ def create_app(config_class: type = Config) -> Flask:
         return render_template(
             "public/property_view.html",
             prop=prop,
+            images=images,
+        )
+
+    def _get_apartment_share_serializer() -> URLSafeSerializer:
+        secret_key = app.config.get("SECRET_KEY")
+        return URLSafeSerializer(secret_key, salt="apartment-share")
+
+    @app.route("/a/<token>")
+    def public_apartment_view(token: str):
+        try:
+            serializer = _get_apartment_share_serializer()
+            apartment_id = serializer.loads(token)
+        except BadSignature:
+            return abort(404)
+
+        from .models import Apartment, Property  # local import to avoid circulars
+
+        apt = Apartment.query.get_or_404(int(apartment_id))
+        building = Property.query.get_or_404(int(apt.building_id))
+
+        # Prepare images list from stored comma-separated paths
+        images = []
+        if apt.images:
+            images = [p.strip() for p in apt.images.split(",") if p.strip()]
+
+        return render_template(
+            "public/apartment_view.html",
+            apt=apt,
+            building=building,
             images=images,
         )
 

--- a/app/employee/routes.py
+++ b/app/employee/routes.py
@@ -177,11 +177,34 @@ def unleased_units_employee():
         buildings = Property.query.filter(Property.id.in_(building_ids)).all()
         buildings_by_id = {b.id: b for b in buildings}
 
+    # Prepare share URLs for public viewing
+    secret_key = current_app.config.get("SECRET_KEY")
+    prop_serializer = URLSafeSerializer(secret_key, salt="property-share")
+    apt_serializer = URLSafeSerializer(secret_key, salt="apartment-share")
+
+    property_share_urls = {}
+    for p in standalone_apartments:
+        try:
+            token = prop_serializer.dumps(p.id)
+            property_share_urls[p.id] = url_for("public_property_view", token=token, _external=True)
+        except Exception:
+            property_share_urls[p.id] = ""
+
+    apartment_share_urls = {}
+    for a in building_apartments:
+        try:
+            token = apt_serializer.dumps(a.id)
+            apartment_share_urls[a.id] = url_for("public_apartment_view", token=token, _external=True)
+        except Exception:
+            apartment_share_urls[a.id] = ""
+
     return render_template(
         "employee/unleased_units.html",
         standalone_apartments=standalone_apartments,
         building_apartments=building_apartments,
         buildings_by_id=buildings_by_id,
+        property_share_urls=property_share_urls,
+        apartment_share_urls=apartment_share_urls,
     )
 
 

--- a/app/templates/employee/unleased_units.html
+++ b/app/templates/employee/unleased_units.html
@@ -29,7 +29,13 @@
         <div>{{ a.title or (a.number and ( _('Apartment') ~ ' ' ~ a.number )) or _('Apartment') }}</div>
         <div class="subtle">{{ _('Building') }}: {{ building and building.title or ('#' ~ a.building_id) }}</div>
       </div>
-      <span class="property-status status-available">{{ _('Available') }}</span>
+      <div class="d-flex align-items-center gap-2">
+        <button class="btn btn-sm btn-outline-primary" type="button"
+                onclick="navigator.clipboard.writeText('{{ apartment_share_urls.get(a.id) }}'); this.innerText='{{ _('Copied') }}'; setTimeout(()=>this.innerText='{{ _('Share') }}',1500);">
+          <i class="bi bi-share"></i> {{ _('Share') }}
+        </button>
+        <span class="property-status status-available">{{ _('Available') }}</span>
+      </div>
     </div>
   </div>
   {% else %}
@@ -45,7 +51,13 @@
     <img src="{{ first_p_image and url_for('uploaded_file', filename=first_p_image) or url_for('static', filename='default-apartment.jpg') }}" alt="{{ p.title }}">
     <div class="property-info">
       <span>{{ p.title }}</span>
-      <span class="property-status status-available">{{ _('Available') }}</span>
+      <div class="d-flex align-items-center gap-2">
+        <button class="btn btn-sm btn-outline-primary" type="button"
+                onclick="navigator.clipboard.writeText('{{ property_share_urls.get(p.id) }}'); this.innerText='{{ _('Copied') }}'; setTimeout(()=>this.innerText='{{ _('Share') }}',1500);">
+          <i class="bi bi-share"></i> {{ _('Share') }}
+        </button>
+        <span class="property-status status-available">{{ _('Available') }}</span>
+      </div>
     </div>
   </div>
   {% else %}

--- a/app/templates/public/apartment_view.html
+++ b/app/templates/public/apartment_view.html
@@ -1,0 +1,95 @@
+{% extends 'base.html' %}
+{% block title %}{{ (apt.title or (apt.number and ( _('Apartment') ~ ' ' ~ apt.number )) or _('Apartment')) }}{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ (building.title or '') }} - {{ (apt.bedrooms or '-') }} {{ _('Bedrooms') }}, {{ (apt.bathrooms or '-') }} {{ _('Bathrooms') }}" />
+<link rel="canonical" href="{{ request.base_url }}" />
+
+{# Open Graph #}
+<meta property="og:type" content="article" />
+<meta property="og:locale" content="{{ get_locale() }}" />
+<meta property="og:title" content="{{ (apt.title or (apt.number and ( _('Apartment') ~ ' ' ~ apt.number )) or _('Apartment')) }} - {{ building.title }}" />
+<meta property="og:description" content="{{ (building.title or '') }}" />
+<meta property="og:url" content="{{ request.base_url }}" />
+{% set og_image = images[0] if images and images|length > 0 else None %}
+{% if og_image %}
+<meta property="og:image" content="{{ url_for('uploaded_file', filename=og_image, _external=True) }}" />
+<meta property="og:image:alt" content="{{ (apt.title or (apt.number and ( _('Apartment') ~ ' ' ~ apt.number )) or _('Apartment')) }}" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+{% endif %}
+
+{# Twitter #}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ (apt.title or (apt.number and ( _('Apartment') ~ ' ' ~ apt.number )) or _('Apartment')) }} - {{ building.title }}" />
+<meta name="twitter:description" content="{{ (building.title or '') }}" />
+{% if og_image %}
+<meta name="twitter:image" content="{{ url_for('uploaded_file', filename=og_image, _external=True) }}" />
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-lg-7">
+    {% if images and images|length > 0 %}
+    <div id="apartmentGallery" class="mb-3">
+      <div id="carouselIndicators" class="carousel slide" data-bs-ride="carousel">
+        <div class="carousel-inner">
+          {% for img in images %}
+          <div class="carousel-item {% if loop.index0 == 0 %}active{% endif %}">
+            <img src="{{ url_for('uploaded_file', filename=img) }}" class="d-block w-100 gallery-image rounded" alt="{{ building.title }}" />
+          </div>
+          {% endfor %}
+        </div>
+        <button class="carousel-control-prev" type="button" data-bs-target="#carouselIndicators" data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#carouselIndicators" data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Next</span>
+        </button>
+      </div>
+      {% if images|length > 1 %}
+      <div class="d-flex justify-content-center mt-2 gap-2">
+        {% for img in images %}
+        <img src="{{ url_for('uploaded_file', filename=img) }}" class="img-thumbnail" style="width:60px; cursor:pointer;"
+          onclick="var idx={{ loop.index0 }}; var carousel=document.getElementById('carouselIndicators'); var carouselInstance=bootstrap.Carousel.getInstance(carousel); carouselInstance.to(idx);">
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+    {% else %}
+    <div class="alert alert-info">{{ _('No images available') }}</div>
+    {% endif %}
+  </div>
+
+  <div class="col-lg-5">
+    <h1 class="h3 mb-3">{{ (apt.title or (apt.number and ( _('Apartment') ~ ' ' ~ apt.number )) or _('Apartment')) }}</h1>
+
+    <div class="mb-2">
+      <span class="badge {% if apt.status=='available' %}bg-success{% elif apt.status=='occupied' %}bg-warning{% else %}bg-secondary{% endif %}">
+        {{ apt.status|capitalize }}
+      </span>
+      <span class="badge bg-info">{{ _('Building') }}: {{ building.title }}</span>
+    </div>
+
+    <div class="mt-3">
+      <span class="badge bg-secondary">{{ _('Bedrooms') }}: {{ apt.bedrooms or '-' }}</span>
+      <span class="badge bg-secondary">{{ _('Bathrooms') }}: {{ apt.bathrooms or '-' }}</span>
+      <span class="badge bg-secondary">{{ _('Area (sqm)') }}: {{ apt.area_sqm or '-' }}</span>
+      <span class="badge bg-secondary">{{ _('Floor') }}: {{ apt.floor or '-' }}</span>
+      {% if apt.rent_price %}
+      <span class="badge bg-secondary">{{ _('Rent price') }}: {{ "{:,.2f}".format(apt.rent_price) }} {{ _('USD') }}</span>
+      {% endif %}
+    </div>
+
+    <div class="mt-3">
+      <button class="btn btn-outline-primary" type="button"
+        onclick="navigator.clipboard.writeText(window.location.href); this.innerText='{{ _('Copied') }}'; setTimeout(()=>this.innerText='{{ _('Copy Link') }}',1500);">
+        {{ _('Copy Link') }}
+      </button>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Add public share links for unleased apartments so clients can view details and images.

---
<a href="https://cursor.com/background-agent?bcId=bc-47484743-ba78-4833-baf6-cd4449b62adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47484743-ba78-4833-baf6-cd4449b62adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

