### PR TITLE
Define allowed check-in/out locations

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, jsonify
 from flask_login import login_required, current_user
 from flask_babel import gettext as _
-from ..models import Property, Contract, Payment, User, Apartment, Attendance
+from ..models import Property, Contract, Payment, User, Apartment, Attendance, AllowedLocation
 from ..extensions import db
 from flask import request, redirect, url_for, flash
 from datetime import date, datetime, timedelta
@@ -24,6 +24,88 @@ def admin_required(func):
 
     return wrapper
 
+
+@admin_bp.route("/allowed-locations")
+@login_required
+@admin_required
+def allowed_locations_list():
+    locations = AllowedLocation.query.order_by(AllowedLocation.created_at.desc()).all()
+    return render_template("admin/allowed_locations_list.html", locations=locations)
+
+
+@admin_bp.route("/allowed-locations/new", methods=["GET", "POST"])
+@login_required
+@admin_required
+def allowed_locations_new():
+    if request.method == "POST":
+        name = (request.form.get("name") or "").strip()
+        lat = request.form.get("latitude")
+        lng = request.form.get("longitude")
+        radius = request.form.get("radius_meters")
+        active = True if (request.form.get("active") == "on") else False
+        if not name:
+            flash(_("All fields are required"), "warning")
+            return redirect(url_for("admin.allowed_locations_new"))
+        try:
+            lat_v = float(lat)
+            lng_v = float(lng)
+            radius_v = int(radius)
+        except Exception:
+            flash(_("Invalid coordinates or radius"), "danger")
+            return redirect(url_for("admin.allowed_locations_new"))
+        loc = AllowedLocation(
+            name=name,
+            latitude=lat_v,
+            longitude=lng_v,
+            radius_meters=radius_v,
+            active=active,
+            created_by_user_id=getattr(current_user, "id", None),
+        )
+        db.session.add(loc)
+        db.session.commit()
+        flash(_("Location created"), "success")
+        return redirect(url_for("admin.allowed_locations_list"))
+    return render_template("admin/allowed_location_form.html", location=None)
+
+
+@admin_bp.route("/allowed-locations/<int:loc_id>/edit", methods=["GET", "POST"])
+@login_required
+@admin_required
+def allowed_locations_edit(loc_id: int):
+    loc = AllowedLocation.query.get_or_404(loc_id)
+    if request.method == "POST":
+        name = (request.form.get("name") or "").strip()
+        lat = request.form.get("latitude")
+        lng = request.form.get("longitude")
+        radius = request.form.get("radius_meters")
+        active = True if (request.form.get("active") == "on") else False
+        if not name:
+            flash(_("All fields are required"), "warning")
+            return redirect(url_for("admin.allowed_locations_edit", loc_id=loc.id))
+        try:
+            loc.latitude = float(lat)
+            loc.longitude = float(lng)
+            loc.radius_meters = int(radius)
+        except Exception:
+            flash(_("Invalid coordinates or radius"), "danger")
+            return redirect(url_for("admin.allowed_locations_edit", loc_id=loc.id))
+        loc.name = name
+        loc.active = active
+        db.session.commit()
+        flash(_("Location updated"), "success")
+        return redirect(url_for("admin.allowed_locations_list"))
+    return render_template("admin/allowed_location_form.html", location=loc)
+
+
+@admin_bp.route("/allowed-locations/<int:loc_id>/delete", methods=["POST"])
+@login_required
+@admin_required
+def allowed_locations_delete(loc_id: int):
+    loc = AllowedLocation.query.get_or_404(loc_id)
+    db.session.delete(loc)
+    db.session.commit()
+    flash(_("Location deleted"), "info")
+    return redirect(url_for("admin.allowed_locations_list"))
 
 @admin_bp.route("/")
 @login_required

--- a/app/employee/routes.py
+++ b/app/employee/routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, abort, request, redirect, url_for,
 from flask_login import login_required, current_user
 from flask_babel import gettext as _
 from ..extensions import db
-from ..models import Property, Contract, MaintenanceRequest, Complaint, Apartment, Payment, User, Attendance
+from ..models import Property, Contract, MaintenanceRequest, Complaint, Apartment, Payment, User, Attendance, AllowedLocation
 from werkzeug.utils import secure_filename
 import uuid
 import os
@@ -22,6 +22,18 @@ def employee_required(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def _haversine_meters(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    import math
+    r = 6371000.0  # Earth radius in meters
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return r * c
 
 
 @employee_bp.route("/")
@@ -151,6 +163,27 @@ def attendance_action(action: str):
     lng = data.get("lng")
     now = datetime.now()
     today = date.today()
+
+    # Enforce allowed geofenced locations if any are defined
+    active_locations = AllowedLocation.query.filter(AllowedLocation.active == True).all()  # noqa: E712
+    if active_locations:
+        # Require coordinates if geofencing is configured
+        try:
+            lat_val = float(lat)
+            lng_val = float(lng)
+        except (TypeError, ValueError):
+            return jsonify({"error": "لا يمكن إتمام العملية بدون تحديد الموقع"}), 400
+        within_allowed = False
+        for loc in active_locations:
+            try:
+                dist = _haversine_meters(lat_val, lng_val, float(loc.latitude), float(loc.longitude))
+            except Exception:
+                continue
+            if dist <= float(loc.radius_meters or 0):
+                within_allowed = True
+                break
+        if not within_allowed:
+            return jsonify({"error": "الموقع الحالي خارج النطاق المسموح به للتسجيل"}), 400
 
     # Find or create today's attendance record
     record = Attendance.query.filter(

--- a/app/models.py
+++ b/app/models.py
@@ -255,3 +255,16 @@ class Attendance(db.Model, TimestampMixin):
         db.UniqueConstraint("employee_id", "date", name="uix_attendance_employee_date"),
         db.Index("ix_attendance_employee_date", "employee_id", "date"),
     )
+
+
+class AllowedLocation(db.Model, TimestampMixin):
+    __tablename__ = "allowed_locations"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    latitude = db.Column(db.Float, nullable=False)
+    longitude = db.Column(db.Float, nullable=False)
+    radius_meters = db.Column(db.Integer, nullable=False, default=100)
+    active = db.Column(db.Boolean, nullable=False, default=True, index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+

--- a/app/templates/admin/allowed_location_form.html
+++ b/app/templates/admin/allowed_location_form.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}{{ location and _('Edit Location') or _('New Location') }}{% endblock %}
+{% block content %}
+<h3 class="mb-3"><i class="bi bi-geo"></i> {{ location and _('Edit Location') or _('New Location') }}</h3>
+<form method="post" class="row g-3" autocomplete="off">
+  <div class="col-md-6">
+    <label class="form-label">{{ _('Name') }}</label>
+    <input type="text" name="name" class="form-control" value="{{ location and location.name or '' }}" required />
+  </div>
+  <div class="col-md-3">
+    <label class="form-label">{{ _('Latitude') }}</label>
+    <input type="number" step="0.000001" name="latitude" class="form-control" value="{{ location and location.latitude or '' }}" required />
+  </div>
+  <div class="col-md-3">
+    <label class="form-label">{{ _('Longitude') }}</label>
+    <input type="number" step="0.000001" name="longitude" class="form-control" value="{{ location and location.longitude or '' }}" required />
+  </div>
+  <div class="col-md-3">
+    <label class="form-label">{{ _('Radius (m)') }}</label>
+    <input type="number" min="10" step="1" name="radius_meters" class="form-control" value="{{ location and location.radius_meters or 100 }}" required />
+  </div>
+  <div class="col-md-3 form-check align-self-end ms-2">
+    <input type="checkbox" class="form-check-input" id="activeCheck" name="active" {% if not location or location.active %}checked{% endif %} />
+    <label class="form-check-label" for="activeCheck">{{ _('Active') }}</label>
+  </div>
+  <div class="col-12 mt-2">
+    <button class="btn btn-primary" type="submit"><i class="bi bi-save"></i> {{ _('Save') }}</button>
+    <a class="btn btn-secondary" href="{{ url_for('admin.allowed_locations_list') }}">{{ _('Cancel') }}</a>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/admin/allowed_locations_list.html
+++ b/app/templates/admin/allowed_locations_list.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block title %}{{ _('Allowed Locations') }}{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h3><i class="bi bi-geo"></i> {{ _('Allowed Locations') }}</h3>
+  <a href="{{ url_for('admin.allowed_locations_new') }}" class="btn btn-primary btn-sm">
+    <i class="bi bi-plus"></i> {{ _('New Location') }}
+  </a>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        <th>{{ _('Name') }}</th>
+        <th>{{ _('Latitude') }}</th>
+        <th>{{ _('Longitude') }}</th>
+        <th>{{ _('Radius (m)') }}</th>
+        <th>{{ _('Active') }}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for l in locations %}
+      <tr>
+        <td>{{ l.name }}</td>
+        <td>{{ '%.6f'|format(l.latitude) }}</td>
+        <td>{{ '%.6f'|format(l.longitude) }}</td>
+        <td>{{ l.radius_meters }}</td>
+        <td>
+          {% if l.active %}<span class="badge bg-success">{{ _('Yes') }}</span>
+          {% else %}<span class="badge bg-secondary">{{ _('No') }}</span>{% endif %}
+        </td>
+        <td class="text-end">
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin.allowed_locations_edit', loc_id=l.id) }}">
+            <i class="bi bi-pencil"></i> {{ _('Edit') }}
+          </a>
+          <form action="{{ url_for('admin.allowed_locations_delete', loc_id=l.id) }}" method="post" class="d-inline" onsubmit="return confirm('{{ _('Delete this location?') }}');">
+            <button class="btn btn-sm btn-outline-danger" type="submit"><i class="bi bi-trash"></i> {{ _('Delete') }}</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+      {% if not locations %}
+      <tr><td colspan="6" class="text-center text-muted">{{ _('No locations yet') }}</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -39,6 +39,7 @@
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.dashboard') }}">{{ _('Admin') }}</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.users_list') }}">{{ _('Users') }}</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.attendance_dashboard') }}">{{ _('Attendance') }}</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.allowed_locations_list') }}">{{ _('Allowed Locations') }}</a></li>
             <li class="nav-item"><a class="nav-link" href="{{ url_for('employee.properties_list') }}">{{ _('Properties') }}</a></li>
             {% endif %}
             {% if current_user.role == 'employee' %}

--- a/app/templates/employee/attendance.html
+++ b/app/templates/employee/attendance.html
@@ -85,7 +85,12 @@
       if (!navigator.geolocation) return resolve(null);
       navigator.geolocation.getCurrentPosition(
         pos => resolve(pos.coords),
-        _err => resolve(null),
+        err => {
+          // Surface geolocation errors to the user for clarity
+          const msg = err && err.message ? err.message : 'Location unavailable';
+          showAlert('warning', msg);
+          resolve(null);
+        },
         { enableHighAccuracy: true, timeout: 8000, maximumAge: 0 }
       );
     });


### PR DESCRIPTION
Allow managers to define geofenced locations for employee attendance check-in/out to enforce location-based work policies.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f34d69c-f1e8-4292-a4d2-8c8c3b934925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f34d69c-f1e8-4292-a4d2-8c8c3b934925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

